### PR TITLE
Add support in Element for namespaces and prefixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xmltree"
 version = "0.3.2"
-authors = ["Andrew Chin <achin@eminence32.net>"]
+authors = ["Andrew Chin <achin@eminence32.net>", "Joey Ezechiels <joey.ezechiels@gmail.com>"]
 description = "Parse an XML file into a simple tree-like structure"
 documentation = "http://eminence.github.io/xmltree-rs/doc/xmltree/index.html"
 repository = "https://github.com/eminence/xmltree-rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@ use xml::reader::{EventReader, XmlEvent};
 /// Represents an XML element.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Element {
+    pub prefix: Option<String>,
+
     pub namespace: Option<String>,
 
     /// The name of the Element.  Does not include any namespace info
@@ -107,7 +109,8 @@ fn build<B: Read>(reader: &mut EventReader<B>, mut elem: Element)
                     attr_map.insert(attr.name.local_name, attr.value);
                 }
                 let new_elem = Element {
-                    namespace: None, // TODO:
+                    prefix: name.prefix,
+                    namespace: name.namespace,
                     name: name.local_name,
                     attributes: attr_map,
                     children: Vec::new(),
@@ -134,14 +137,15 @@ impl Element {
         let mut reader = EventReader::new(r);
         loop {
             match reader.next() {
-                Ok(XmlEvent::StartElement{name, attributes, ..}) => {
+                Ok(XmlEvent::StartElement { name, attributes, .. }) => {
                     let mut attr_map = HashMap::new();
                     for attr in attributes {
                         attr_map.insert(attr.name.local_name, attr.value);
                     }
 
                     let root = Element {
-                        namespace: None, // TODO:
+                        prefix: name.prefix,
+                        namespace: name.namespace,
                         name: name.local_name,
                         attributes: attr_map,
                         children: Vec::new(),
@@ -190,11 +194,10 @@ impl Element {
             elem._write(emitter);
         }
         emitter.write(XmlEvent::EndElement{name: Some(name)}).unwrap();
-
     }
 
     /// Writes out this element as the root element in an new XML document
-    pub fn write<W: Write>(&self, w:W) {
+    pub fn write<W: Write>(&self, w: W) {
         use xml::writer::EventWriter;
         use xml::writer::events::XmlEvent;
         use xml::common::XmlVersion;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! }
 //! names_element.write(File::create("result.xml").unwrap());
 //!
-//! 
+//!
 //! ```
 extern crate xml;
 
@@ -182,13 +182,13 @@ impl Element {
     }
 
     /// Find a child element with the given name and return a reference to it.
-    pub fn get_child<K>(&self, k: K) -> Option<&Element> 
+    pub fn get_child<K>(&self, k: K) -> Option<&Element>
       where String: PartialEq<K> {
           self.children.iter().find(|e| e.name == k)
     }
 
     /// Find a child element with the given name and return a mutable reference to it.
-    pub fn get_mut_child<'a, K>(&'a mut self, k: K) -> Option<&'a mut Element> 
+    pub fn get_mut_child<'a, K>(&'a mut self, k: K) -> Option<&'a mut Element>
       where String: PartialEq<K> {
           self.children.iter_mut().find(|e| e.name == k)
     }
@@ -199,4 +199,3 @@ impl Element {
           self.children.iter().position(|e| e.name == k).map(|i| self.children.remove(i))
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@ use xml::reader::{EventReader, XmlEvent};
 /// Represents an XML element.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Element {
+    pub namespace: Option<String>,
+
     /// The name of the Element.  Does not include any namespace info
     pub name: String,
 
@@ -88,21 +90,29 @@ impl std::error::Error for ParseError {
     }
 }
 
-fn build<B: Read>(reader: &mut EventReader<B>, mut elem: Element) -> Result<Element, ParseError> {
+fn build<B: Read>(reader: &mut EventReader<B>, mut elem: Element)
+                  -> Result<Element, ParseError> {
     loop {
         match reader.next() {
             Ok(XmlEvent::EndElement{ref name}) => {
                 if name.local_name == elem.name {
                     return Ok(elem);
-                }
-                else {
+                } else {
                     return Err(ParseError::CannotParse);
                 }
             },
             Ok(XmlEvent::StartElement{name, attributes, ..}) => {
                 let mut attr_map = HashMap::new();
-                for attr in attributes { attr_map.insert(attr.name.local_name, attr.value); }
-                let new_elem = Element{name: name.local_name, attributes: attr_map, children: Vec::new(), text: None};
+                for attr in attributes {
+                    attr_map.insert(attr.name.local_name, attr.value);
+                }
+                let new_elem = Element {
+                    namespace: None, // TODO:
+                    name: name.local_name,
+                    attributes: attr_map,
+                    children: Vec::new(),
+                    text: None
+                };
                 elem.children.push(try!(build(reader, new_elem)));
             }
             Ok(XmlEvent::Characters(s)) => { elem.text = Some(s); }
@@ -126,9 +136,17 @@ impl Element {
             match reader.next() {
                 Ok(XmlEvent::StartElement{name, attributes, ..}) => {
                     let mut attr_map = HashMap::new();
-                    for attr in attributes { attr_map.insert(attr.name.local_name, attr.value); }
+                    for attr in attributes {
+                        attr_map.insert(attr.name.local_name, attr.value);
+                    }
 
-                    let root = Element{name: name.local_name, attributes: attr_map, children: Vec::new(), text: None};
+                    let root = Element {
+                        namespace: None, // TODO:
+                        name: name.local_name,
+                        attributes: attr_map,
+                        children: Vec::new(),
+                        text: None
+                    };
                     return build(&mut reader, root);
                 }
                 Ok(XmlEvent::Comment(..)) |
@@ -138,7 +156,8 @@ impl Element {
                 Ok(XmlEvent::EndElement { .. }) |
                 Ok(XmlEvent::Characters(..)) |
                 Ok(XmlEvent::CData(..)) |
-                Ok(XmlEvent::ProcessingInstruction { .. }) => return Err(ParseError::CannotParse),
+                Ok(XmlEvent::ProcessingInstruction { .. }) =>
+                    return Err(ParseError::CannotParse),
                 Err(e) => return Err(ParseError::MalformedXml(e)),
             }
         }
@@ -159,7 +178,11 @@ impl Element {
         let namespace = Namespace::empty();
 
 
-        emitter.write(XmlEvent::StartElement{name: name, attributes: Cow::Owned(attributes), namespace: Cow::Borrowed(&namespace)}).unwrap();
+        emitter.write(XmlEvent::StartElement {
+            name: name,
+            attributes: Cow::Owned(attributes),
+            namespace: Cow::Borrowed(&namespace)
+        }).unwrap();
         if let Some(ref t) = self.text {
             emitter.write(XmlEvent::Characters(t)).unwrap();
         }
@@ -177,25 +200,33 @@ impl Element {
         use xml::common::XmlVersion;
 
         let mut emitter = EventWriter::new(w);
-        emitter.write(XmlEvent::StartDocument{version: XmlVersion::Version10, encoding: None, standalone: None}).unwrap();
+        emitter.write(XmlEvent::StartDocument {
+            version: XmlVersion::Version10,
+            encoding: None,
+            standalone: None
+        }).unwrap();
         self._write(&mut emitter);
     }
 
-    /// Find a child element with the given name and return a reference to it.
+    /// Find a child element with the given name and
+    /// return a reference to it.
     pub fn get_child<K>(&self, k: K) -> Option<&Element>
       where String: PartialEq<K> {
           self.children.iter().find(|e| e.name == k)
     }
 
-    /// Find a child element with the given name and return a mutable reference to it.
+    /// Find a child element with the given name and
+    /// return a mutable reference to it.
     pub fn get_mut_child<'a, K>(&'a mut self, k: K) -> Option<&'a mut Element>
-      where String: PartialEq<K> {
-          self.children.iter_mut().find(|e| e.name == k)
+        where String: PartialEq<K> {
+        self.children.iter_mut().find(|e| e.name == k)
     }
 
     /// Find a child element with the given name, remove and return it.
-    pub fn take_child<'a, K>(&'a mut self, k: K) -> Option<Element>
-      where String: PartialEq<K> {
-          self.children.iter().position(|e| e.name == k).map(|i| self.children.remove(i))
+    pub fn take_child<'a, K>(&'a mut self, k: K)
+                             -> Option<Element> where String: PartialEq<K> {
+        self.children.iter()
+            .position(|e| e.name == k)
+            .map(|i| self.children.remove(i))
     }
 }


### PR DESCRIPTION
The first couple of commits are not that interesting, mostly they deal with administrative stuff.
The last commit is noteworthy however: it adds support to the `Element` type for the `namespace` and a `prefix` fields, which I need for my project.

I'd much rather commit back than maintain a fork, so a merge would be much appreciated.