### PR TITLE
update xml-rs dependency to 0.8, fix warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["parsing", "data-structures"]
 
 
 [dependencies]
-xml-rs = "0.7"
+xml-rs = "0.8"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,7 +134,7 @@ fn build<B: Read>(reader: &mut EventReader<B>, mut elem: Element) -> Result<Elem
                     children: Vec::new(),
                     text: None,
                 };
-                elem.children.push(try!(build(reader, new_elem)));
+                elem.children.push(build(reader, new_elem)?);
             }
             Ok(XmlEvent::Characters(s)) => {
                 elem.text = Some(s);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,7 +93,7 @@ impl std::error::Error for ParseError {
         }
     }
 
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             ParseError::MalformedXml(ref e) => Some(e),
             ParseError::CannotParse => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,7 +211,6 @@ impl Element {
     fn _write<B: Write>(&self, emitter: &mut xml::writer::EventWriter<B>) -> Result<(), Error> {
         use xml::writer::events::XmlEvent;
         use xml::name::Name;
-        use xml::namespace::Namespace;
         use xml::attribute::Attribute;
 
         let mut name = Name::local(&self.name);


### PR DESCRIPTION
xmltree re-exports some structs from xml-rs, but the compiler thinks that for example xmltree::Namespace and xml::namespace::Namespace are not compatible.

Upgrading the xml-rs dep to 0.8 fixes this, and introduces no other changes. I also noticed a few warnings that I fixed.

It would be nice if you could release a 0.9 with these changes.

Thanks