### PR TITLE
[FEAT] Depth First Traversal Methods

### DIFF
--- a/tests/data/dft.xml
+++ b/tests/data/dft.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<a>
+  <b>
+    <c/>
+  </b>
+  <b/>
+  <c/>
+</a>

--- a/tests/suite.rs
+++ b/tests/suite.rs
@@ -280,3 +280,116 @@ fn test_text() {
         Cow::from("hello <world>".to_owned())
     );
 }
+
+#[test]
+fn test_pre_order_dft_xmlnode() {
+    let nodes: Vec<XMLNode> = parse_all(File::open("tests/data/dft.xml").unwrap()).unwrap();
+    let root_node = nodes.get(0).expect("no root node");
+
+    let pre_order_nodes = root_node.dft_pre_order(None);
+    let collected_nodes = pre_order_nodes.collect::<Vec<&XMLNode>>();
+    
+    assert_eq!(collected_nodes.len(), 5);
+    assert_eq!(collected_nodes.get(0).unwrap().as_element().unwrap().name, "a");
+    assert_eq!(collected_nodes.get(1).unwrap().as_element().unwrap().name, "b");
+    assert_eq!(collected_nodes.get(2).unwrap().as_element().unwrap().name, "c");
+    assert_eq!(collected_nodes.get(3).unwrap().as_element().unwrap().name, "b");
+    assert_eq!(collected_nodes.get(4).unwrap().as_element().unwrap().name, "c");
+}
+
+#[test]
+fn test_pre_order_dft_early_stop_xmlnode() {
+    let nodes: Vec<XMLNode> = parse_all(File::open("tests/data/dft.xml").unwrap()).unwrap();
+    let root_node = nodes.get(0).expect("no root node");
+
+    let pre_order_nodes = root_node.dft_pre_order(Some(|node| node.as_element().unwrap().name == "b"));
+    let collected_nodes = pre_order_nodes.collect::<Vec<&XMLNode>>();
+    
+    assert_eq!(collected_nodes.len(), 4);
+    assert_eq!(collected_nodes.get(0).unwrap().as_element().unwrap().name, "a");
+    assert_eq!(collected_nodes.get(1).unwrap().as_element().unwrap().name, "b");
+    assert_eq!(collected_nodes.get(2).unwrap().as_element().unwrap().name, "b");
+    assert_eq!(collected_nodes.get(3).unwrap().as_element().unwrap().name, "c");
+}
+
+#[test]
+fn test_post_order_dft_xmlnode() {
+    let nodes: Vec<XMLNode> = parse_all(File::open("tests/data/dft.xml").unwrap()).unwrap();
+    let root_node = nodes.get(0).expect("no root node");
+
+    let post_order_nodes = root_node.dft_post_order(None);
+    let collected_nodes = post_order_nodes.collect::<Vec<&XMLNode>>();
+    
+    assert_eq!(collected_nodes.len(), 5);
+    assert_eq!(collected_nodes.get(0).unwrap().as_element().unwrap().name, "c");
+    assert_eq!(collected_nodes.get(1).unwrap().as_element().unwrap().name, "b");
+    assert_eq!(collected_nodes.get(2).unwrap().as_element().unwrap().name, "b");
+    assert_eq!(collected_nodes.get(3).unwrap().as_element().unwrap().name, "c");
+    assert_eq!(collected_nodes.get(4).unwrap().as_element().unwrap().name, "a");
+}
+
+#[test]
+fn test_post_order_dft_early_stop_xmlnode() {
+    let nodes: Vec<XMLNode> = parse_all(File::open("tests/data/dft.xml").unwrap()).unwrap();
+    let root_node = nodes.get(0).expect("no root node");
+
+    fn predicate(node: &XMLNode) -> bool {
+        node.as_element().unwrap().name == "b"
+    }
+
+    let post_order_nodes = root_node.dft_post_order(Some(predicate));
+    let collected_nodes = post_order_nodes.collect::<Vec<&XMLNode>>();
+    
+    assert_eq!(collected_nodes.len(), 4);
+    assert_eq!(collected_nodes.get(0).unwrap().as_element().unwrap().name, "b");
+    assert_eq!(collected_nodes.get(1).unwrap().as_element().unwrap().name, "b");
+    assert_eq!(collected_nodes.get(2).unwrap().as_element().unwrap().name, "c");
+    assert_eq!(collected_nodes.get(3).unwrap().as_element().unwrap().name, "a");
+}
+
+#[test]
+fn test_pre_order_dft_early_stop_element() {
+    let root_node: Element = parse(File::open("tests/data/dft.xml").unwrap()).unwrap();
+
+    let pre_order_nodes = root_node.dft_pre_order(Some(|node| node.name == "b"));
+    let collected_nodes = pre_order_nodes.collect::<Vec<&Element>>();
+    
+    assert_eq!(collected_nodes.len(), 4);
+    assert_eq!(collected_nodes.get(0).unwrap().name, "a");
+    assert_eq!(collected_nodes.get(1).unwrap().name, "b");
+    assert_eq!(collected_nodes.get(2).unwrap().name, "b");
+    assert_eq!(collected_nodes.get(3).unwrap().name, "c");
+}
+
+#[test]
+fn test_post_order_dft_element() {
+    let root_node: Element = parse(File::open("tests/data/dft.xml").unwrap()).unwrap();
+
+    let post_order_nodes = root_node.dft_post_order(None);
+    let collected_nodes = post_order_nodes.collect::<Vec<&Element>>();
+    
+    assert_eq!(collected_nodes.len(), 5);
+    assert_eq!(collected_nodes.get(0).unwrap().name, "c");
+    assert_eq!(collected_nodes.get(1).unwrap().name, "b");
+    assert_eq!(collected_nodes.get(2).unwrap().name, "b");
+    assert_eq!(collected_nodes.get(3).unwrap().name, "c");
+    assert_eq!(collected_nodes.get(4).unwrap().name, "a");
+}
+
+#[test]
+fn test_post_order_dft_early_stop_element() {
+    let root_node: Element = parse(File::open("tests/data/dft.xml").unwrap()).unwrap();
+
+    fn predicate(node: &Element) -> bool {
+        node.name == "b"
+    }
+
+    let post_order_nodes = root_node.dft_post_order(Some(predicate));
+    let collected_nodes = post_order_nodes.collect::<Vec<&Element>>();
+    
+    assert_eq!(collected_nodes.len(), 4);
+    assert_eq!(collected_nodes.get(0).unwrap().name, "b");
+    assert_eq!(collected_nodes.get(1).unwrap().name, "b");
+    assert_eq!(collected_nodes.get(2).unwrap().name, "c");
+    assert_eq!(collected_nodes.get(3).unwrap().name, "a");
+}


### PR DESCRIPTION
This adds traits and implementations to do depth first traversals (both pre-order and post-order). It's still rough and needs some work to organize the api and code, but it should provide some good utility to finding nodes in the tree efficiently.

Definitely still needs discussion before it would be ready for consideration for merging.

Additionally moved the parse and parse_all functions into the module scope rather than scoped to Element (though they are still on Element and delegated to the module scope functions to keep backwards compatibility). <- This needs to be moved into another PR I think.

I think some additional questions to be answered:
 - Is there a need to have both pre and post order traversals or is one sufficient?
 - Is there a need to have traversal methods on both Element and XMLNode?
 - Does the performance benefit of having a depth stop predicate sufficiently pay for the API overhead? (perhaps two methods, but that seems confusing as well)
 - Probably need mutable iterators as well