### PR TITLE
Add feature to use IndexMap instead of HashMap. Fixes #21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,12 @@ keywords = ["xml", "parse", "xmltree"]
 license = "MIT"
 readme = "README.md"
 categories = ["parsing", "data-structures"]
-
+edition = "2018"
 
 [dependencies]
 xml-rs = "0.8"
+indexmap = { version = "1.4.0", optional = true }
 
+[features]
+default = []
+attribute-order = ["indexmap"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Add the following to your `Cargo.toml` file:
 xmltree = "0.10"
 ```
 
+### Feature-flags
+
+* `attribute-order` - change the data structure that stores attributes into one that keeps a
+consistent order. This changes the type definition and adds another dependency.
+
 ## Compatability with xml-rs
 This crate will export some types from the xml-rs crate.  If your own crate also uses the xml-rs
 crate, but with a different version, the types may be incompatible.  One way to solve this is to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,13 +31,16 @@
 extern crate xml;
 
 use std::borrow::Cow;
-use std::collections::HashMap;
+#[cfg(not(feature = "attribute-order"))]
+use std::collections::HashMap as AttributeMap;
 use std::fmt;
 use std::io::{Read, Write};
 
 pub use xml::namespace::Namespace;
 use xml::reader::{EventReader, ParserConfig, XmlEvent};
 pub use xml::writer::{EmitterConfig, Error};
+#[cfg(feature = "attribute-order")]
+use indexmap::map::IndexMap as AttributeMap;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum XMLNode {
@@ -104,7 +107,7 @@ pub struct Element {
     pub name: String,
 
     /// The Element attributes
-    pub attributes: HashMap<String, String>,
+    pub attributes: AttributeMap<String, String>,
 
     /// Children
     pub children: Vec<XMLNode>,
@@ -160,7 +163,7 @@ fn build<B: Read>(reader: &mut EventReader<B>, mut elem: Element) -> Result<Elem
                 attributes,
                 namespace,
             }) => {
-                let mut attr_map = HashMap::new();
+                let mut attr_map = AttributeMap::new();
                 for attr in attributes {
                     attr_map.insert(attr.name.local_name, attr.value);
                 }
@@ -205,7 +208,7 @@ impl Element {
             prefix: None,
             namespace: None,
             namespaces: None,
-            attributes: HashMap::new(),
+            attributes: AttributeMap::new(),
             children: Vec::new(),
         }
     }
@@ -225,7 +228,7 @@ impl Element {
                     attributes,
                     namespace,
                 }) => {
-                    let mut attr_map = HashMap::with_capacity(attributes.len());
+                    let mut attr_map = AttributeMap::with_capacity(attributes.len());
                     for attr in attributes {
                         attr_map.insert(attr.name.local_name, attr.value);
                     }


### PR DESCRIPTION
IndexMap will preserve insertion-order, thus it makes xmltree
both mirror input file order and output deterministically.

~~This is a breaking change to the API, as another codebase may
refer to HashMap by type, even though the APIs are similarly
named.~~

I added a feature-gate to the functionality, but the import by optional dependency was bugging out without `2018`. If that matters, let me know.

I used `AttributeMap` as the type-name to not convolute possible changes in the future that may also use `HashMap`.