### PR TITLE
Add `attribute-sorted` feature that emits attributes in sorted order

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ indexmap = { version = "1.4.0", optional = true }
 [features]
 default = []
 attribute-order = ["indexmap"]
+attribute-sorted = []

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ xmltree = "0.10"
 
 ### Feature-flags
 
-* `attribute-order` - change the data structure that stores attributes into one that keeps a
-consistent order. This changes the type definition and adds another dependency.
+* `attribute-order` - change the data structure that stores attributes to one that uses insertion order. This changes the type definition and adds another dependency.
+
+* `attribute-sorted` - change the data structure that stores attributes to one that uses sorted order. This changes the type definition.
 
 ## Compatability with xml-rs
 This crate will export some types from the xml-rs crate.  If your own crate also uses the xml-rs


### PR DESCRIPTION
This adds a new feature called `attribute-sorted` that causes attributes to be stored in a `BTreeMap`, and thus always be in sorted order.

I wasn't sure how to add tests, since the `attribute-order` feature doesn't seem to be tested either.