### PR TITLE
Add `Element::matches()` to easily check if an element matches a pred…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,6 +480,11 @@ impl Element {
             Some(Cow::Owned(full_text))
         }
     }
+
+    /// Checks if this element matches the predicate.
+    pub fn matches<P: ElementPredicate>(&self, k: P) -> bool {
+        k.match_element(self)
+    }
 }
 
 /// A predicate for matching elements.


### PR DESCRIPTION
…icate

Unlike `predicate.matches(&element)` this does not require the trait to be in scope and also leads to more naturally reading code.