### PR TITLE
Discriminate between attributes in different namespaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xmltree"
-version = "0.10.3"
+version = "0.11.0"
 authors = ["Andrew Chin <achin@eminence32.net>"]
 description = "Parse an XML file into a simple tree-like structure"
 documentation = "https://docs.rs/xmltree/"
@@ -9,7 +9,7 @@ keywords = ["xml", "parse", "xmltree"]
 license = "MIT"
 readme = "README.md"
 categories = ["parsing", "data-structures"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 xml-rs = "0.8"

--- a/tests/data/issue13.xml
+++ b/tests/data/issue13.xml
@@ -1,0 +1,5 @@
+<EntitiesDescriptor Name="urn:mace:shibboleth:testshib:two" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui">
+  <mdui:DisplayName xml:lang="en">TestShib Test IdP</mdui:DisplayName>
+  <mdui:Description xml:lang="en">TestShib IdP. Use this as a source of attributes for your test SP.</mdui:Description>
+  <mdui:Logo height="88" width="253">https://www.testshib.org/testshibtwo.jpg</mdui:Logo>
+</EntitiesDescriptor>

--- a/tests/data/multi-attribute-ns.xml
+++ b/tests/data/multi-attribute-ns.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<node xmlns:ext="http://dbus.extensions.com/schemas/dbus-extensions-v1.0">
+     <ext:member type="i" ext:type="[ExtendedType]" name="extendedType" >
+    </ext:member> 
+</node>


### PR DESCRIPTION
This commit is an alternative approach to fixing https://github.com/eminence/xmltree-rs/issues/13 (Attribute namespaces are not preserved), inspired by the discussion on https://github.com/eminence/xmltree-rs/pull/33. It changes the type of the `attributes` map on the `Element` struct from a String -> String map to an AttributeName -> String map. AttributeName is a re-export of the xml::name::OwnedName type in xmltree-rs, which is a struct containing the attribute's local name, namespace and prefix.

It is possible to search the `attributes` map using a fully initialised AttributeName structure, but for convenience get_attribute(), get_mut_attribute() and take_attribute() methods, modelled on the *_element() equivalent are provided, which take an AttributePredicate. Ready-made implementations taking either a local name or local name + namespace are provided.

This is a semver-breaking change, hence version is incremented to 0.11.0, I'm not sure if it is necessary to provide some kind of backward-compatibility compile time switch?

I was in two minds as to how closely to follow the pattern of the existing `take_element()`, `get_element()` etc. APIs. While writing the tests I realised that those APIs do not allow you to pass `None` for the namespace, you can either pass just the local name, and ignore namespace, or local name + namespace. This means it's not possible to explicitly search for elements with no namespace, which seems like a defect to me.

My initial implementation, which I still have on a branch, had implementations of the `AttributePredicate` trait for `String`, `&str` and `Cow<&str>` just like the the Element equivalents, but having these and an implementation for `(N, Option<NS>)` to allow the namespace to be specified means that if you want to pass `None` the type is ambiguous so you have to specify which string-like type you mean, e.g. `<Option<String>>::None`. This seemed quite awkward so this version only supports `&str`. I can of course change this if required.