### PR TITLE
Discriminate between attributes in different namespaces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ keywords = ["xml", "parse", "xmltree"]
 license = "MIT"
 readme = "README.md"
 categories = ["parsing", "data-structures"]
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 xml = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //! # Example
 //!
 //! ```no_run
-//! use xmltree::Element;
+//! use xmltree::{AttributeName, Element};
 //! use std::fs::File;
 //!
 //! let data: &'static str = r##"
@@ -22,7 +22,7 @@
 //! {
 //!     // get first `name` element
 //!     let name = names_element.get_mut_child("name").expect("Can't find name element");
-//!     name.attributes.insert("suffix".to_owned(), "mr".to_owned());
+//!     name.attributes.insert(AttributeName::local("suffix"), "mr".to_owned());
 //! }
 //! names_element.write(File::create("result.xml").unwrap());
 //!
@@ -54,6 +54,7 @@ use std::borrow::Cow;
 use std::fmt;
 use std::io::{Read, Write};
 
+pub use xml::name::OwnedName as AttributeName;
 pub use xml::namespace::Namespace;
 pub use xml::reader::ParserConfig;
 use xml::reader::{EventReader, XmlEvent};
@@ -155,7 +156,7 @@ pub struct Element {
     /// * If the "attribute-order" feature is enabled, then this is an [IndexMap](https://docs.rs/indexmap/2/indexmap/),
     ///   which will retain item insertion order.
     /// * If the "attribute-sorted" feature is enabled, then this is a [`std::collections::BTreeMap`], which maintains keys in sorted order.
-    pub attributes: AttributeMap<String, String>,
+    pub attributes: AttributeMap<AttributeName, String>,
 
     /// Children
     pub children: Vec<XMLNode>,
@@ -213,7 +214,7 @@ fn build<B: Read>(reader: &mut EventReader<B>, mut elem: Element) -> Result<Elem
             }) => {
                 let mut attr_map = AttributeMap::new();
                 for attr in attributes {
-                    attr_map.insert(attr.name.local_name, attr.value);
+                    attr_map.insert(attr.name, attr.value);
                 }
 
                 let new_elem = Element {
@@ -286,7 +287,7 @@ impl Element {
                 }) => {
                     let mut attr_map = AttributeMap::allocate(attributes.len());
                     for attr in attributes {
-                        attr_map.insert(attr.name.local_name, attr.value);
+                        attr_map.insert(attr.name, attr.value);
                     }
 
                     let root = Element {
@@ -361,7 +362,7 @@ impl Element {
         let mut attributes = Vec::with_capacity(self.attributes.len());
         for (k, v) in &self.attributes {
             attributes.push(Attribute {
-                name: Name::local(k),
+                name: k.borrow(),
                 value: v,
             });
         }
@@ -488,10 +489,47 @@ impl Element {
             Some(Cow::Owned(full_text))
         }
     }
-
     /// Checks if this element matches the predicate.
     pub fn matches<P: ElementPredicate>(&self, k: P) -> bool {
         k.match_element(self)
+    }
+
+    /// Get a reference to the value of an attribute matching the provided predicate.
+    ///
+    /// Note that this will be slower than searching `attributes` directly as
+    /// it iterates over the entries in the map.
+    pub fn get_attribute<P: AttributePredicate>(&self, k: P) -> Option<&String> {
+        self.attributes
+            .iter()
+            .find(|pair| k.match_attribute(pair.0))
+            .map(|pair| pair.1)
+    }
+
+    /// Get a &mut to the value of an attribute matching the provided predicate.
+    ///
+    /// Note that this will be slower than searching `attributes` directly as
+    /// it iterates over the entries in the map.
+    pub fn get_mut_attribute<P: AttributePredicate>(&mut self, k: P) -> Option<&mut String> {
+        self.attributes
+            .iter_mut()
+            .find(|pair| k.match_attribute(pair.0))
+            .map(|pair| pair.1)
+    }
+
+    /// Find an attribute matching the provided predicate, remove, and return its value.
+    ///
+    /// Note that this will be slower than operating on `attributes` directly as
+    /// it iterates over the entries in the map.
+    pub fn take_attribute<P: AttributePredicate>(&mut self, k: P) -> Option<String> {
+        if let Some(key) = self
+            .attributes
+            .keys()
+            .find(|name| k.match_attribute(name))
+            .cloned()
+        {
+            return self.attributes.remove(&key);
+        }
+        None
     }
 }
 
@@ -553,5 +591,31 @@ where
                 .as_ref()
                 .map(|ns| ns == &self.1)
                 .unwrap_or(false)
+    }
+}
+
+/// A predicate for matching attributes.
+///
+/// The default implementations allow you to match by attribute name or a tuple of
+/// attribute name and namespace.
+pub trait AttributePredicate {
+    fn match_attribute(&self, n: &AttributeName) -> bool;
+}
+
+impl<'a, 'b> AttributePredicate for (&'a str, Option<&'b str>) {
+    fn match_attribute(&self, n: &AttributeName) -> bool {
+        n.local_name == self.0
+            && match (&n.namespace, &self.1) {
+                (None, None) => true,
+                (Some(ns1), Some(ns2)) => ns1 == ns2,
+                _ => false,
+            }
+    }
+}
+
+impl<'a> AttributePredicate for &'a str {
+    /// Search by attribute name
+    fn match_attribute(&self, n: &AttributeName) -> bool {
+        n.local_name == *self
     }
 }

--- a/tests/data/issue13.xml
+++ b/tests/data/issue13.xml
@@ -1,0 +1,5 @@
+<EntitiesDescriptor Name="urn:mace:shibboleth:testshib:two" xmlns:mdui="urn:oasis:names:tc:SAML:metadata:ui">
+  <mdui:DisplayName xml:lang="en">TestShib Test IdP</mdui:DisplayName>
+  <mdui:Description xml:lang="en">TestShib IdP. Use this as a source of attributes for your test SP.</mdui:Description>
+  <mdui:Logo height="88" width="253">https://www.testshib.org/testshibtwo.jpg</mdui:Logo>
+</EntitiesDescriptor>

--- a/tests/data/multi-attribute-ns.xml
+++ b/tests/data/multi-attribute-ns.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<node xmlns:ext="http://dbus.extensions.com/schemas/dbus-extensions-v1.0">
+     <ext:member type="i" ext:type="[ExtendedType]" name="extendedType" >
+    </ext:member> 
+</node>

--- a/tests/suite.rs
+++ b/tests/suite.rs
@@ -80,7 +80,8 @@ fn test_mut() {
     let mut e: Element = Element::parse(File::open("tests/data/rw.xml").unwrap()).unwrap();
     {
         let name = e.get_mut_child("name").unwrap();
-        name.attributes.insert("suffix".to_owned(), "mr".to_owned());
+        name.attributes
+            .insert(AttributeName::local("suffix"), "mr".to_owned());
     }
 }
 
@@ -301,5 +302,90 @@ fn test_decl() {
     assert_eq!(
         String::from_utf8(output).unwrap(),
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?><n />"
+    );
+}
+
+#[test]
+fn test_attribute_ns1() {
+    let e: Element = Element::parse(File::open("tests/data/issue13.xml").unwrap()).unwrap();
+
+    let display_name_elem = e
+        .get_child(("DisplayName", "urn:oasis:names:tc:SAML:metadata:ui"))
+        .unwrap();
+    assert_eq!(display_name_elem.attributes.len(), 1);
+
+    // Search map using AttributeName struct
+    let attribute_name = AttributeName {
+        local_name: "lang".to_string(),
+        namespace: Some("http://www.w3.org/XML/1998/namespace".to_string()),
+        prefix: Some("xml".to_string()),
+    };
+    assert_eq!(
+        display_name_elem.attributes.get(&attribute_name).unwrap(),
+        "en"
+    );
+
+    // Search by name + namespace
+    let attribute_value = display_name_elem
+        .get_attribute(("lang", Some("http://www.w3.org/XML/1998/namespace")))
+        .unwrap();
+    assert_eq!(attribute_value, "en");
+
+    assert_eq!(
+        None,
+        display_name_elem.get_attribute(("lang", Some("https://www.w3schools.com/furniture")))
+    );
+
+    // Search by name as a &str
+    assert_eq!("en", display_name_elem.get_attribute("lang").unwrap());
+
+    assert_eq!(None, display_name_elem.get_attribute("no_such_attribute"));
+}
+
+#[test]
+fn test_multi_attribute_names() {
+    let ext_ns = "http://dbus.extensions.com/schemas/dbus-extensions-v1.0";
+    let mut e = Element::parse(File::open("tests/data/multi-attribute-ns.xml").unwrap()).unwrap();
+    let mut member_elem = e.take_child(("member", ext_ns)).unwrap();
+
+    // Get the first "type" attribute (in one namespace)
+    assert_ne!(None, member_elem.take_attribute("type"));
+    // Get the second "type" attribute (in the other namespace)
+    assert_ne!(None, member_elem.take_attribute("type"));
+    // Should be no more "type" attributes
+    assert_eq!(None, member_elem.take_attribute("type"));
+
+    e = Element::parse(File::open("tests/data/multi-attribute-ns.xml").unwrap()).unwrap();
+    member_elem = e.take_child(("member", ext_ns)).unwrap();
+
+    assert_eq!("i", member_elem.take_attribute(("type", None)).unwrap());
+    assert_eq!(None, member_elem.take_attribute(("type", None)));
+
+    assert_eq!(
+        "[ExtendedType]",
+        member_elem.take_attribute(("type", Some(ext_ns))).unwrap()
+    );
+    assert_eq!(None, member_elem.take_attribute(("type", Some(ext_ns))));
+}
+
+#[test]
+fn test_mutable_attributes() {
+    let ext_ns = "http://dbus.extensions.com/schemas/dbus-extensions-v1.0";
+    let mut e = Element::parse(File::open("tests/data/multi-attribute-ns.xml").unwrap()).unwrap();
+    let mut member_elem = e.take_child(("member", ext_ns)).unwrap();
+
+    let new_val = "New value".to_string();
+    let attr_val: &mut String = member_elem.get_mut_attribute(("type", None)).unwrap();
+    *attr_val = new_val.clone();
+    assert_eq!(&new_val, member_elem.get_attribute(("type", None)).unwrap());
+
+    let new_ext_val = "New extended attr".to_string();
+    let ext_attr_val: &mut String = member_elem
+        .get_mut_attribute(("type", Some(ext_ns)))
+        .unwrap();
+    *ext_attr_val = new_ext_val.clone();
+    assert_eq!(
+        &new_ext_val,
+        member_elem.get_attribute(("type", Some(ext_ns))).unwrap()
     );
 }


### PR DESCRIPTION
This commit aims to fix https://github.com/eminence/xmltree-rs/issues/13 (Attribute namespaces are not preserved). It changes the type of the `attributes` map on the `Element` struct from a String -> String map to an AttributeName -> String map. AttributeName is a re-export of the xml::name::OwnedName type in xmltree-rs, which is a struct containing the attribute's local name, namespace and prefix.

It is possible to search the `attributes` map using a fully initialised AttributeName structure, but for convenience get_attribute(), get_mut_attribute() and take_attribute() methods, modelled on the *_element() equivalent are provided, which take an AttributePredicate. Ready-made implementations taking either a local name or local name + namespace are provided.