### PR TITLE
Make parse/write iterative to fix issue #58

### DIFF
--- a/benches/suite.rs
+++ b/benches/suite.rs
@@ -149,8 +149,11 @@ fn bench_new(b: &mut Bencher) {
 
 #[bench]
 fn bench_take(b: &mut Bencher) {
-    let data_xml_1 = r##"
-        <?xml version="1.0" encoding="utf-8" standalone="yes"?>
+    // The XML spec only allows `<?xml` at the very first byte of the
+    // document; any leading whitespace (e.g. a newline from an indented
+    // raw string) makes recent xml-rs versions reject the input as
+    // malformed. Keep these raw strings starting at column zero.
+    let data_xml_1 = r##"<?xml version="1.0" encoding="utf-8" standalone="yes"?>
         <names>
             <name first="bob" last="jones"></name>
             <name first="elizabeth" last="smith" />
@@ -160,8 +163,7 @@ fn bench_take(b: &mut Bencher) {
         </names>
     "##;
 
-    let data_xml_2 = r##"
-        <?xml version="1.0" encoding="utf-8" standalone="yes"?>
+    let data_xml_2 = r##"<?xml version="1.0" encoding="utf-8" standalone="yes"?>
         <names>
             <name first="bob" last="jones"></name>
             <name first="elizabeth" last="smith" />

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,11 @@ pub use xml::reader::ParserConfig;
 use xml::reader::{EventReader, XmlEvent};
 pub use xml::writer::{EmitterConfig, Error};
 
+// TODO: the derived Debug, Clone, and PartialEq impls recurse over the
+// nesting depth (through `Element::children`) and can overflow the stack
+// on deeply nested documents. Iterative implementations are possible
+// without changing semantics.
+// Related issue #58
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum XMLNode {
     Element(Element),
@@ -131,6 +136,13 @@ impl XMLNode {
     }
 }
 
+// TODO: the derived Debug, Clone, and PartialEq impls recurse over the
+// nesting depth and can overflow the stack on deeply nested documents.
+// The implicit drop glue for the `children` tree recurses as well; an
+// iterative `Drop` impl would fix that, but it is a breaking change
+// (fields can no longer be moved out of a type with a `Drop` impl), so it
+// needs a deliberate semver decision.
+// Related issue #58
 /// Represents an XML element.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Element {
@@ -196,14 +208,63 @@ impl std::error::Error for ParseError {
     }
 }
 
-fn build<B: Read>(reader: &mut EventReader<B>, mut elem: Element) -> Result<Element, ParseError> {
+/// Moves every `Element` child of `elem` onto `stack`, leaving
+/// `elem.children` empty.
+fn push_element_children(elem: &mut Element, stack: &mut Vec<Element>) {
+    for node in elem.children.drain(..) {
+        if let XMLNode::Element(child) = node {
+            stack.push(child);
+        }
+    }
+}
+
+/// Flattens the trees rooted at `roots` iteratively, so that dropping
+/// them does not recurse over the nesting depth. The implicit drop glue
+/// walks `children` recursively and overflows the stack on deeply nested
+/// documents (see the TODO on `Element`), so error paths that already
+/// hold a partially or fully assembled tree must dismantle it this way.
+///
+/// TODO: if `Element` ever grows an iterative `Drop` impl (a breaking
+/// change, see issue #58 and the TODO on `Element`), these manual
+/// error-path dismantles become unnecessary and can be removed.
+fn flatten_trees(mut roots: Vec<Element>) {
+    let mut stack = Vec::new();
+    for root in &mut roots {
+        push_element_children(root, &mut stack);
+    }
+    while let Some(mut elem) = stack.pop() {
+        push_element_children(&mut elem, &mut stack);
+    }
+}
+
+/// Dismantles the partially built tree held by `elem` and `parents`
+/// without recursive drop glue (see `flatten_trees`) and returns `err`.
+fn fail_build(elem: &mut Element, parents: &mut Vec<Element>, err: ParseError) -> ParseError {
+    let mut roots = std::mem::take(parents);
+    roots.push(std::mem::replace(elem, Element::new("")));
+    flatten_trees(roots);
+    err
+}
+
+fn build<B: Read>(reader: &mut EventReader<B>, root: Element) -> Result<Element, ParseError> {
+    // Build the tree iteratively: `elem` is the element currently being
+    // filled, `parents` holds its still-open ancestors. Nesting depth is
+    // therefore bounded by heap memory instead of the thread stack. When an
+    // EndElement closes the root (no parent left), the document is complete.
+    let mut parents: Vec<Element> = Vec::new();
+    let mut elem = root;
     loop {
         match reader.next() {
             Ok(XmlEvent::EndElement { ref name }) => {
-                if name.local_name == elem.name {
-                    return Ok(elem);
-                } else {
-                    return Err(ParseError::CannotParse);
+                if name.local_name != elem.name {
+                    return Err(fail_build(&mut elem, &mut parents, ParseError::CannotParse));
+                }
+                match parents.pop() {
+                    Some(mut parent) => {
+                        parent.children.push(XMLNode::Element(elem));
+                        elem = parent;
+                    }
+                    None => return Ok(elem),
                 }
             }
             Ok(XmlEvent::StartElement {
@@ -228,8 +289,8 @@ fn build<B: Read>(reader: &mut EventReader<B>, mut elem: Element) -> Result<Elem
                     attributes: attr_map,
                     children: Vec::new(),
                 };
-                elem.children
-                    .push(XMLNode::Element(build(reader, new_elem)?));
+                parents.push(elem);
+                elem = new_elem;
             }
             Ok(XmlEvent::Characters(s)) => elem.children.push(XMLNode::Text(s)),
             Ok(XmlEvent::Whitespace(..)) => (),
@@ -239,10 +300,16 @@ fn build<B: Read>(reader: &mut EventReader<B>, mut elem: Element) -> Result<Elem
                 .children
                 .push(XMLNode::ProcessingInstruction(name, data)),
             Ok(XmlEvent::StartDocument { .. }) | Ok(XmlEvent::EndDocument) => {
-                return Err(ParseError::CannotParse)
+                return Err(fail_build(&mut elem, &mut parents, ParseError::CannotParse));
             }
             Ok(XmlEvent::Doctype { .. }) => (),
-            Err(e) => return Err(ParseError::MalformedXml(e)),
+            Err(e) => {
+                return Err(fail_build(
+                    &mut elem,
+                    &mut parents,
+                    ParseError::MalformedXml(e),
+                ));
+            }
         }
     }
 }
@@ -317,7 +384,20 @@ impl Element {
                 Ok(XmlEvent::EndElement { .. }) => (),
                 Ok(XmlEvent::EndDocument) => return Ok(root_nodes),
                 Ok(XmlEvent::Doctype { .. }) => (),
-                Err(e) => return Err(ParseError::MalformedXml(e)),
+                Err(e) => {
+                    // Completed root trees may be deeply nested; flatten
+                    // them iteratively so the error return does not drop
+                    // them through the recursive drop glue.
+                    let roots = root_nodes
+                        .drain(..)
+                        .filter_map(|node| match node {
+                            XMLNode::Element(elem) => Some(elem),
+                            _ => None,
+                        })
+                        .collect();
+                    flatten_trees(roots);
+                    return Err(ParseError::MalformedXml(e));
+                }
             }
         }
     }
@@ -330,8 +410,10 @@ impl Element {
                 return Ok(elem);
             }
         }
-        // This assume the underlying xml library throws an error on no root element
-        unreachable!();
+        // Reached only if the document contained no root element. xml-rs
+        // currently enforces the root requirement itself, so this is
+        // defense in depth: an error, never a panic.
+        Err(ParseError::CannotParse)
     }
 
     pub fn parse_with_config<R: Read>(r: R, config: ParserConfig) -> Result<Element, ParseError> {
@@ -341,22 +423,32 @@ impl Element {
                 return Ok(elem);
             }
         }
-        // This assume the underlying xml library throws an error on no root element
-        unreachable!();
+        // Reached only if the document contained no root element. xml-rs
+        // currently enforces the root requirement itself, so this is
+        // defense in depth: an error, never a panic.
+        Err(ParseError::CannotParse)
     }
 
-    fn _write<B: Write>(&self, emitter: &mut xml::writer::EventWriter<B>) -> Result<(), Error> {
-        use xml::attribute::Attribute;
-        use xml::name::Name;
-        use xml::writer::events::XmlEvent;
-
-        let mut name = Name::local(&self.name);
+    /// Builds the `Name` for this element, carrying namespace and prefix
+    /// information if present. Shared by start-tag and end-tag emission.
+    fn xml_name(&self) -> xml::name::Name<'_> {
+        let mut name = xml::name::Name::local(&self.name);
         if let Some(ref ns) = self.namespace {
             name.namespace = Some(ns);
         }
         if let Some(ref p) = self.prefix {
             name.prefix = Some(p);
         }
+        name
+    }
+
+    fn write_start_tag<B: Write>(
+        &self,
+        emitter: &mut xml::writer::EventWriter<B>,
+    ) -> Result<(), Error> {
+        use xml::attribute::Attribute;
+        use xml::name::Name;
+        use xml::writer::events::XmlEvent;
 
         let mut attributes = Vec::with_capacity(self.attributes.len());
         for (k, v) in &self.attributes {
@@ -374,27 +466,58 @@ impl Element {
         };
 
         emitter.write(XmlEvent::StartElement {
-            name,
+            name: self.xml_name(),
             attributes: Cow::Owned(attributes),
             namespace,
-        })?;
-        for node in &self.children {
-            match node {
-                XMLNode::Element(elem) => elem._write(emitter)?,
-                XMLNode::Text(text) => emitter.write(XmlEvent::Characters(text))?,
-                XMLNode::Comment(comment) => emitter.write(XmlEvent::Comment(comment))?,
-                XMLNode::CData(comment) => emitter.write(XmlEvent::CData(comment))?,
-                XMLNode::ProcessingInstruction(name, data) => match data.to_owned() {
-                    Some(string) => emitter.write(XmlEvent::ProcessingInstruction {
-                        name,
-                        data: Some(&string),
-                    })?,
-                    None => emitter.write(XmlEvent::ProcessingInstruction { name, data: None })?,
-                },
+        })
+    }
+
+    fn write_end_tag<B: Write>(
+        &self,
+        emitter: &mut xml::writer::EventWriter<B>,
+    ) -> Result<(), Error> {
+        use xml::writer::events::XmlEvent;
+
+        emitter.write(XmlEvent::EndElement {
+            name: Some(self.xml_name()),
+        })
+    }
+
+    fn _write<B: Write>(&self, emitter: &mut xml::writer::EventWriter<B>) -> Result<(), Error> {
+        use xml::writer::events::XmlEvent;
+
+        // Walk the tree iteratively with an explicit stack of
+        // (element, next child index) frames, so that nesting depth is
+        // bounded by heap memory instead of the thread stack.
+        self.write_start_tag(emitter)?;
+        let mut stack: Vec<(&Element, usize)> = vec![(self, 0)];
+        while let Some(top) = stack.last_mut() {
+            let elem: &Element = top.0;
+            if top.1 < elem.children.len() {
+                let node = &elem.children[top.1];
+                top.1 += 1;
+                match node {
+                    XMLNode::Element(child) => {
+                        child.write_start_tag(emitter)?;
+                        stack.push((child, 0));
+                    }
+                    XMLNode::Text(text) => emitter.write(XmlEvent::Characters(text))?,
+                    XMLNode::Comment(comment) => emitter.write(XmlEvent::Comment(comment))?,
+                    XMLNode::CData(cdata) => emitter.write(XmlEvent::CData(cdata))?,
+                    XMLNode::ProcessingInstruction(name, data) => match data {
+                        Some(string) => emitter.write(XmlEvent::ProcessingInstruction {
+                            name,
+                            data: Some(string.as_str()),
+                        })?,
+                        None => {
+                            emitter.write(XmlEvent::ProcessingInstruction { name, data: None })?
+                        }
+                    },
+                }
+            } else if let Some((elem, _)) = stack.pop() {
+                elem.write_end_tag(emitter)?;
             }
-            // elem._write(emitter)?;
         }
-        emitter.write(XmlEvent::EndElement { name: Some(name) })?;
 
         Ok(())
     }
@@ -470,8 +593,8 @@ impl Element {
     /// Returns the inner text/cdata of this element, if any.
     ///
     /// If there are multiple text/cdata nodes, they will be all concatenated into one string.
-    pub fn get_text<'a>(&'a self) -> Option<Cow<'a, str>> {
-        let text_nodes: Vec<&'a str> = self
+    pub fn get_text(&self) -> Option<Cow<'_, str>> {
+        let text_nodes: Vec<&str> = self
             .children
             .iter()
             .filter_map(|node| node.as_text().or_else(|| node.as_cdata()))
@@ -520,7 +643,7 @@ where
     }
 }
 
-impl<'a> ElementPredicate for &'a str {
+impl ElementPredicate for &str {
     /// Search by tag name
     fn match_element(&self, e: &Element) -> bool {
         (*self,).match_element(e)

--- a/tests/deep_nesting.rs
+++ b/tests/deep_nesting.rs
@@ -1,0 +1,118 @@
+//! Smoke tests for deeply nested documents.
+//!
+//! Regression coverage for <https://github.com/eminence/xmltree-rs/issues/58>:
+//! parsing or writing a deeply nested tree must not overflow the thread
+//! stack. These tests are expected to abort the test harness when run
+//! against a recursive implementation.
+//!
+//! Note: dropping a deeply nested tree still recurses through
+//! `Vec<XMLNode>` drop glue. That is out of scope for the parse/write fix,
+//! so the trees below are wrapped in `ManuallyDrop` to keep both the
+//! success and the panic paths off the recursive drop glue.
+
+use std::io::Cursor;
+use std::mem::ManuallyDrop;
+
+use xmltree::{Element, ParseError, XMLNode};
+
+/// Matches the nesting depth from the issue #58 reproducer.
+const DEPTH: usize = 30_000;
+
+fn deeply_nested_document(depth: usize) -> String {
+    let mut xml = String::with_capacity(depth * 7 + 14);
+    xml.push_str("<root>");
+    for _ in 0..depth {
+        xml.push_str("<x>");
+    }
+    for _ in 0..depth {
+        xml.push_str("</x>");
+    }
+    xml.push_str("</root>");
+    xml
+}
+
+fn deeply_nested_tree(depth: usize) -> Element {
+    let mut root = Element::new("root");
+    {
+        let mut current = &mut root;
+        for _ in 0..depth {
+            current.children.push(XMLNode::Element(Element::new("x")));
+            current = current
+                .children
+                .last_mut()
+                .and_then(XMLNode::as_mut_element)
+                .unwrap();
+        }
+    }
+    root
+}
+
+fn assert_nesting_depth(elem: &Element, expected: usize) {
+    let mut current = elem;
+    let mut depth = 0;
+    while let Some(child) = current.get_child("x") {
+        depth += 1;
+        current = child;
+    }
+    assert_eq!(depth, expected);
+    assert!(current.children.is_empty());
+}
+
+#[test]
+fn parses_deeply_nested_document() {
+    let xml = deeply_nested_document(DEPTH);
+
+    let root = ManuallyDrop::new(Element::parse(Cursor::new(xml)).unwrap());
+
+    assert_eq!(root.name, "root");
+    assert_nesting_depth(&root, DEPTH);
+}
+
+#[test]
+fn writes_deeply_nested_document() {
+    // Build the tree directly so this test exercises `_write` even if
+    // parsing were to gain an independent depth limit in the future.
+    let root = ManuallyDrop::new(deeply_nested_tree(DEPTH));
+
+    let mut buf = Vec::new();
+    root.write(&mut buf).unwrap();
+
+    // Re-parse the output and check it structurally with an iterative
+    // walk. Comparing the trees with the derived `PartialEq` (or `Debug`,
+    // `Clone`, drop) would recurse over the nesting depth; those derived
+    // impls are out of scope for the parse/write fix.
+    let reparsed = ManuallyDrop::new(Element::parse(Cursor::new(buf)).unwrap());
+    assert_eq!(reparsed.name, "root");
+    assert_nesting_depth(&reparsed, DEPTH);
+}
+
+#[test]
+fn error_path_inside_build_does_not_overflow_drop() {
+    // The deep chain is fully closed inside `<a>`, so at the moment the
+    // malformed input arrives, `parents`/`elem` in `build()` hold the
+    // completely assembled 30k-deep tree. Returning the error must not
+    // drop that tree recursively (drop glue would overflow the stack).
+    let mut xml = String::from("<root><a>");
+    for _ in 0..DEPTH {
+        xml.push_str("<x>");
+    }
+    for _ in 0..DEPTH {
+        xml.push_str("</x>");
+    }
+    xml.push('<'); // truncated tag: xml-rs errors inside build()
+
+    let result = Element::parse(Cursor::new(xml));
+    assert!(matches!(result, Err(ParseError::MalformedXml(_))));
+}
+
+#[test]
+fn error_path_after_completed_root_does_not_overflow_drop() {
+    // A complete deep document followed by trailing junk: `parse_all`
+    // errors while `root_nodes` holds the finished deep tree. Same
+    // drop-glue hazard on the error path.
+    let mut xml = deeply_nested_document(DEPTH);
+    xml.push('<');
+
+    let result = Element::parse(Cursor::new(xml));
+    assert!(matches!(result, Err(ParseError::MalformedXml(_))));
+}

--- a/tests/suite.rs
+++ b/tests/suite.rs
@@ -303,3 +303,73 @@ fn test_decl() {
         "<?xml version=\"1.0\" encoding=\"UTF-8\"?><n />"
     );
 }
+
+#[test]
+fn test_comment_only_document_errors() {
+    // A document without a root element is rejected. xml-rs itself
+    // enforces the root requirement at the lexer level, so this surfaces
+    // as MalformedXml rather than CannotParse.
+    let data = r#"<?xml version="1.0"?><!-- nothing but a comment -->"#;
+
+    match Element::parse(data.as_bytes()) {
+        Err(ParseError::MalformedXml(_)) => {}
+        other => panic!("expected MalformedXml, got {:?}", other.is_ok()),
+    }
+
+    match Element::parse_with_config(data.as_bytes(), ParserConfig::new()) {
+        Err(ParseError::MalformedXml(_)) => {}
+        other => panic!("expected MalformedXml, got {:?}", other.is_ok()),
+    }
+}
+
+#[test]
+fn test_parse_all_comment_only() {
+    // parse_all is likewise rejected by xml-rs before any nodes are
+    // produced: the root requirement applies to the stream, not to our
+    // tree assembly.
+    let data = r#"<?xml version="1.0"?><!-- first --><!-- second -->"#;
+
+    match Element::parse_all(data.as_bytes()) {
+        Err(ParseError::MalformedXml(_)) => {}
+        other => panic!("expected MalformedXml, got {:?}", other.is_ok()),
+    }
+}
+
+#[test]
+fn test_roundtrip_all_node_types() {
+    // Every XMLNode variant must survive a parse -> write -> parse cycle:
+    // attributes, text, comment, CDATA, processing instruction, and
+    // nested elements, in order.
+    let data = r#"<?xml version="1.0"?>
+<root a="1" b="2">text before<!-- a comment --><child key="value">inner</child><![CDATA[<raw>&data;]]><?target some data?>text after</root>"#;
+
+    let e = Element::parse(data.as_bytes()).unwrap();
+    let mut buf = Vec::new();
+    e.write(&mut buf).unwrap();
+    let e2 = Element::parse(Cursor::new(&buf)).unwrap();
+    assert_eq!(e, e2);
+
+    assert_eq!(e.attributes.get("a").unwrap(), "1");
+    assert_eq!(e.attributes.get("b").unwrap(), "2");
+    assert!(e.children.iter().any(|n| n.as_comment().is_some()));
+    assert!(e.children.iter().any(|n| n.as_cdata().is_some()));
+    assert!(e
+        .children
+        .iter()
+        .any(|n| n.as_processing_instruction().is_some()));
+}
+
+#[test]
+fn test_write_prefixed_end_tag() {
+    // Start AND end tags must both carry the namespace prefix.
+    let data = r#"<x:root xmlns:x="urn:test"><x:child /></x:root>"#;
+
+    let e = Element::parse(data.as_bytes()).unwrap();
+    let mut buf = Vec::new();
+    e.write(&mut buf).unwrap();
+    let out = String::from_utf8(buf).unwrap();
+
+    assert!(out.contains("<x:root"), "start tag lost prefix: {}", out);
+    assert!(out.contains("<x:child"), "child tag lost prefix: {}", out);
+    assert!(out.contains("</x:root>"), "end tag lost prefix: {}", out);
+}


### PR DESCRIPTION
### Iterative `build()` and `_write()`

Both walked the tree recursively, so deeply nested documents overflow the
thread stack (SIGSEGV, not a catchable panic). They now use explicit
heap-allocated stacks: `build()` keeps open ancestors in a `Vec<Element>`,
`_write()` walks with `(&Element, next_child_index)` frames. No clones,
no API changes, no behavior changes — output bytes are identical.

New `tests/deep_nesting.rs` parses and writes a 30,000-level document
(the issue's reproducer depth); it aborts the harness when run against
the recursive implementation.

### Fix `bench_take` data

The input strings had a newline before `<?xml`, which the XML spec
forbids and recent xml-rs rejects — the bench was failing before any
code change. Fixed, with a comment explaining the constraint.

### Drive-bys

- Two `unreachable!()`s in `parse()`/`parse_with_config()` →
  `Err(CannotParse)`. Unreachable through current xml-rs (now pinned by
  tests), but an error beats a panic if that ever changes.
- Two needless-lifetime fixes flagged by clippy.

### Verification

26 tests pass on all three feature combos (default / `attribute-order` /
`attribute-sorted`), `clippy -D warnings` clean, all 12 benches pass with
performance unchanged (bench_01 74,284 → 72,415 ns/iter, within noise).

### Out of scope

Derived `Debug`/`Clone`/`PartialEq` and drop glue still recurse — see the
TODO comments I left at both derive sites. Iterative trait impls are
non-breaking and possible, but iterative `Drop` is breaking (E0509), so
that's a semver decision for a follow-up.

Fixed #58

---

Disclosure: LLM-assisted (tests and iteration), as mentioned in the
issue. I've reviewed every line and take full responsibility for the code.